### PR TITLE
initialisation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,92 +1,108 @@
 import _ from 'lodash';
 
-export default class PiePlayer extends HTMLElement{
+export default class PiePlayer extends HTMLElement {
 
-  createdCallback(){
+  createdCallback() {
     console.log('created');
+
+    this.addEventListener('pie.register', (event) => {
+      let id = event.target.getAttribute('data-id');
+      this._pies[id] = event.target;
+      this._updatePie(id);
+    });
   }
-  
-  attachedCallback(){
+
+  _updatePie(id) {
+
+  }
+
+  attachedCallback() {
     console.log('attached');
-    let event = new CustomEvent('pie-player-ready', {bubbles: true});
+    let event = new CustomEvent('pie-player-ready', { bubbles: true });
     this.dispatchEvent(event);
   }
 
-  set controller(c){
-   this._controller = c; 
-   this._update();
+  set controller(c) {
+    this._controller = c;
+    this._update();
   }
 
-  set env(e){
+  set env(e) {
     this._env = e;
     this._update();
   }
 
-  set session(s){
-   
-   if(!_.isArray(s)){
-     throw new Error('session must be an array');
-   }
+  set session(s) {
 
-   this._session = s; 
-   this._update();
+    if (!_.isArray(s)) {
+      throw new Error('session must be an array');
+    }
+
+    this._session = s;
+    this._update();
   }
 
-  getOutcome(){
+  getOutcome() {
     return this._controller.outcome(this._session, this._env);
   }
 
-  _initSession(ids){
-    if(!this._session){
+  _initSession(ids) {
+    if (!this._session) {
       throw new Error('no session initialised - this must be injected');
-    } 
+    }
 
     _.forEach(ids, (id) => {
-      let hasId = _.find(this._session, {id: id});
-      if(!hasId){
-        this._session.push({id: id});
+      let hasId = _.find(this._session, { id: id });
+      if (!hasId) {
+        this._session.push({ id: id });
       }
     });
   };
 
-  _update(){
-    if(this._controller && this._env && this._session){
+  _update() {
+    if (this._controller && this._env && this._session) {
 
       //TODO - what's the best way for the player to extract it's contents?
-      let els = this.querySelectorAll('[data-id]');
+
+      //1: immediate children // wont work - say one is in a table?
+      //2. query controller? but if the controller is on the server this could be slow
+      //3. query by 'pie-element' attribute? it'd mean the markup would need to be tweaked
+      //4. find all and filter the elements that support `model` and `session` and have a 'data-id'
+      let els = this.querySelectorAll('[pie-id]');
 
       let idToEls = [];
-      els.forEach((e) => idToEls.push({id: e.getAttribute('data-id'), el: e}));
+      els.forEach((e) => {
+        idToEls.push({ id: e.getAttribute('pie-id'), el: e });
 
-      let ids = _.map(idToEls, 'id');
-      this._initSession(ids);
+        let ids = _.map(idToEls, 'id');
+        this._initSession(ids);
 
-      let applyModelAndSession = (models) => {
-        _.map(idToEls, (ie) => {
-          let model = _.find(models, {id: ie.id});
-          let session = _.find(this._session, {id: ie.id});
-          if(model && session){
-            ie.el.model = model;
-            ie.el.session = session;
-          } else {
-            console.error('missing either a model or a sessio: ', model, session);
-          }
-        });
-      };
+        let applyModelAndSession = (models) => {
+          _.map(idToEls, (ie) => {
+            let model = _.find(models, { id: ie.id });
+            let session = _.find(this._session, { id: ie.id });
+            if (model && session) {
+              ie.el.model = model;
+              ie.el.session = session;
+            } else {
+              console.error('missing either a model or a sessio: ', model, session);
+            }
+          });
+        };
 
-      let dispatchModelUpdated = () => {
-        let event = new CustomEvent('pie', {
-          detail: {
-            type: 'modelUpdated'
-          }
-        });
-        console.log('dispatch event..');
-        this.dispatchEvent(event);
-      };
+        let dispatchModelUpdated = () => {
+          let event = new CustomEvent('pie', {
+            detail: {
+              type: 'modelUpdated'
+            }
+          });
+          console.log('dispatch event..');
+          this.dispatchEvent(event);
+        };
 
-      this._controller.model(this._session, this._env)
-        .then(applyModelAndSession)
-        .then(dispatchModelUpdated);
-    }
+        this._controller.model(this._session, this._env)
+          .then(applyModelAndSession)
+          .then(dispatchModelUpdated);
+      }
   }
-}
+  }

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ export default class PiePlayer extends HTMLElement {
     _.forEach(
       this._pies,
       (pie, id) => {
-        this._updateElement(pie, id, (pie, id) => console.error('missing model or session for pie: ' + pie);
+        this._updateElement(pie, id, (pie, id) => console.error('missing model or session for pie: ' + pie));
       }
     );
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,10 +9,17 @@ export default class PiePlayer extends HTMLElement {
       //stop the event from bubbling further
       event.preventDefault();
       event.stopImmediatePropagation();
-      let id = event.target.getAttribute('data-id');
+
+      let id = event.target.getAttribute('pie-id');
+
+      if (!id) {
+        throw new Error('Element is missing a [pie-id] attribute: ' + event.target);
+      }
+
       if (this._pies[id]) {
         throw new Error('a pie with that id (' + id + ') is already registered: ' + this._pies[id]);
       }
+
       this._pies[id] = event.target;
       this._updateElement(event.target, id);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,14 +6,16 @@ export default class PiePlayer extends HTMLElement {
     console.log('created');
 
     this.addEventListener('pie.register', (event) => {
+      //stop the event from bubbling further
+      event.preventDefault();
+      event.stopImmediatePropagation();
       let id = event.target.getAttribute('data-id');
+      if (this._pies[id]) {
+        throw new Error('a pie with that id (' + id + ') is already registered: ' + this._pies[id]);
+      }
       this._pies[id] = event.target;
-      this._updatePie(id);
+      this._updateElement(event.target, id);
     });
-  }
-
-  _updatePie(id) {
-
   }
 
   attachedCallback() {
@@ -61,48 +63,78 @@ export default class PiePlayer extends HTMLElement {
 
   _update() {
     if (this._controller && this._env && this._session) {
+      this._controller.model(this._session, this._env)
+        .then((models) => {
+          this._latestModels = models;
+          this._updateElements();
+        })
+        .then(dispatchModelUpdated);
+    }
+  }
 
-      //TODO - what's the best way for the player to extract it's contents?
+  _updateElement(pie, id, missingModelOrSession) {
+    missingModelOrSession = missingModelOrSession || (() => { });
+    let model = _.find(this._latestModels, { id: id });
+    let session = _.find(this._session, { id: id });
+    if (!model || !session) {
+      missingModelOrSession(pie, id);
+      return;
+    }
+    pie.model = model;
+    pie.session = session;
+  }
 
-      //1: immediate children // wont work - say one is in a table?
-      //2. query controller? but if the controller is on the server this could be slow
-      //3. query by 'pie-element' attribute? it'd mean the markup would need to be tweaked
-      //4. find all and filter the elements that support `model` and `session` and have a 'data-id'
-      let els = this.querySelectorAll('[pie-id]');
-
-      let idToEls = [];
-      els.forEach((e) => {
-        idToEls.push({ id: e.getAttribute('pie-id'), el: e });
-
-        let ids = _.map(idToEls, 'id');
-        this._initSession(ids);
-
-        let applyModelAndSession = (models) => {
-          _.map(idToEls, (ie) => {
-            let model = _.find(models, { id: ie.id });
-            let session = _.find(this._session, { id: ie.id });
-            if (model && session) {
-              ie.el.model = model;
-              ie.el.session = session;
-            } else {
-              console.error('missing either a model or a sessio: ', model, session);
-            }
-          });
-        };
-
-        let dispatchModelUpdated = () => {
-          let event = new CustomEvent('pie', {
-            detail: {
-              type: 'modelUpdated'
-            }
-          });
-          console.log('dispatch event..');
-          this.dispatchEvent(event);
-        };
-
-        this._controller.model(this._session, this._env)
-          .then(applyModelAndSession)
-          .then(dispatchModelUpdated);
+  _updateElements() {
+    _.forEach(
+      this._pies,
+      (pie, id) => {
+        this._updateElement(pie, id, (pie, id) => console.error('missing model or session for pie: ' + pie);
       }
+    );
   }
-  }
+}
+
+  //     //TODO - what's the best way for the player to extract it's contents?
+
+  //     //1: immediate children // wont work - say one is in a table?
+  //     //2. query controller? but if the controller is on the server this could be slow
+  //     //3. query by 'pie-element' attribute? it'd mean the markup would need to be tweaked
+  //     //4. find all and filter the elements that support `model` and `session` and have a 'data-id'
+  //     let els = this.querySelectorAll('[pie-id]');
+
+  //     let idToEls = [];
+  //     els.forEach((e) => {
+  //       idToEls.push({ id: e.getAttribute('pie-id'), el: e });
+
+  //       let ids = _.map(idToEls, 'id');
+  //       this._initSession(ids);
+
+  //       let applyModelAndSession = (models) => {
+  //         _.map(idToEls, (ie) => {
+  //           let model = _.find(models, { id: ie.id });
+  //           let session = _.find(this._session, { id: ie.id });
+  //           if (model && session) {
+  //             ie.el.model = model;
+  //             ie.el.session = session;
+  //           } else {
+  //             console.error('missing either a model or a sessio: ', model, session);
+  //           }
+  //         });
+  //       };
+
+  //       let dispatchModelUpdated = () => {
+  //         let event = new CustomEvent('pie', {
+  //           detail: {
+  //             type: 'modelUpdated'
+  //           }
+  //         });
+  //         console.log('dispatch event..');
+  //         this.dispatchEvent(event);
+  //       };
+
+  //       this._controller.model(this._session, this._env)
+  //         .then(applyModelAndSession)
+  //         .then(dispatchModelUpdated);
+  //     }
+  // }
+  // }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 export default class PiePlayer extends HTMLElement {
 
   createdCallback() {
-    console.log('created');
+    this._pies = {};
 
     this.addEventListener('pie.register', (event) => {
       //stop the event from bubbling further
@@ -19,7 +19,6 @@ export default class PiePlayer extends HTMLElement {
   }
 
   attachedCallback() {
-    console.log('attached');
     let event = new CustomEvent('pie.player-ready', { bubbles: true });
     this.dispatchEvent(event);
   }
@@ -78,10 +77,27 @@ export default class PiePlayer extends HTMLElement {
     }
   }
 
+  _getOrCreateSession(id) {
+
+    //We need to wait for the session to be injected
+    if (!this._session) {
+      return undefined;
+    }
+
+    let existing = _.find(this._session, { id: id });
+    if (existing) {
+      return existing;
+    } else {
+      let out = { id: id };
+      this._session.push(out);
+      return out;
+    }
+  }
+
   _updateElement(pie, id, missingModelOrSession) {
     missingModelOrSession = missingModelOrSession || (() => { });
     let model = _.find(this._latestModels, { id: id });
-    let session = _.find(this._session, { id: id });
+    let session = this._getOrCreateSession(id);
     if (!model || !session) {
       missingModelOrSession(pie, id);
       return;
@@ -99,39 +115,3 @@ export default class PiePlayer extends HTMLElement {
     );
   }
 }
-
-  //     //TODO - what's the best way for the player to extract it's contents?
-
-  //     //1: immediate children // wont work - say one is in a table?
-  //     //2. query controller? but if the controller is on the server this could be slow
-  //     //3. query by 'pie-element' attribute? it'd mean the markup would need to be tweaked
-  //     //4. find all and filter the elements that support `model` and `session` and have a 'data-id'
-  //     let els = this.querySelectorAll('[pie-id]');
-
-  //     let idToEls = [];
-  //     els.forEach((e) => {
-  //       idToEls.push({ id: e.getAttribute('pie-id'), el: e });
-
-  //       let ids = _.map(idToEls, 'id');
-  //       this._initSession(ids);
-
-  //       let applyModelAndSession = (models) => {
-  //         _.map(idToEls, (ie) => {
-  //           let model = _.find(models, { id: ie.id });
-  //           let session = _.find(this._session, { id: ie.id });
-  //           if (model && session) {
-  //             ie.el.model = model;
-  //             ie.el.session = session;
-  //           } else {
-  //             console.error('missing either a model or a sessio: ', model, session);
-  //           }
-  //         });
-  //       };
-
-
-  //       this._controller.model(this._session, this._env)
-  //         .then(applyModelAndSession)
-  //         .then(dispatchModelUpdated);
-  //     }
-  // }
-  // }

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ export default class PiePlayer extends HTMLElement {
 
   attachedCallback() {
     console.log('attached');
-    let event = new CustomEvent('pie-player-ready', { bubbles: true });
+    let event = new CustomEvent('pie.player-ready', { bubbles: true });
     this.dispatchEvent(event);
   }
 
@@ -62,6 +62,12 @@ export default class PiePlayer extends HTMLElement {
   };
 
   _update() {
+
+    let dispatchModelUpdated = () => {
+      let event = new CustomEvent('pie.model-updated');
+      this.dispatchEvent(event);
+    };
+
     if (this._controller && this._env && this._session) {
       this._controller.model(this._session, this._env)
         .then((models) => {
@@ -122,15 +128,6 @@ export default class PiePlayer extends HTMLElement {
   //         });
   //       };
 
-  //       let dispatchModelUpdated = () => {
-  //         let event = new CustomEvent('pie', {
-  //           detail: {
-  //             type: 'modelUpdated'
-  //           }
-  //         });
-  //         console.log('dispatch event..');
-  //         this.dispatchEvent(event);
-  //       };
 
   //       this._controller.model(this._session, this._env)
   //         .then(applyModelAndSession)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-player",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "a pie-player custom element",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.test.html
+++ b/test/index.test.html
@@ -1,10 +1,27 @@
 <!doctype html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <script src="../node_modules/web-component-tester/browser.js"></script>
   <script src="bundle.js"></script>
+  <script type="text/javascript">
+
+
+      var MyCompPrototype = Object.create(HTMLElement.prototype);
+
+      MyCompPrototype.attachedCallback = function() {
+        this.dispatchEvent(new CustomEvent('pie.register', {bubbles: true}));
+      };
+
+      document.registerElement('my-comp', {prototype: MyCompPrototype});
+
+      document.addEventListener('pie.register', function(event){
+        console.log('got a pie.register', event)
+      })
+  </script>
 </head>
+
 <body>
   <pie-player>
     <my-comp data-id="1"></my-comp>
@@ -15,8 +32,7 @@
       var el, mockController;
       beforeEach(function(done){
 
-        this.timeout(30000);
-
+        var calledDone=false;
         mockController = {
           model: sinon.spy(function(){
             console.log('arguments: ' + JSON.stringify(arguments));
@@ -26,9 +42,10 @@
 
         el = document.querySelector('pie-player');
         
-        el.addEventListener('pie', function(event){
+        el.addEventListener('pie.model-updated', function(event){
           console.log('model has been updated');
-          if(event.detail.type === 'modelUpdated'){
+          if(!calledDone){
+            calledDone = true;
             done();
           }
         });
@@ -39,13 +56,27 @@
       });
 
       it('isnt null', function() {
+        console.log("???");
         expect(el).not.to.be.null;
       });
 
+      it('has 1 _pie at _pie[1]', function(){
+        expect(el._pies['1']).not.to.be.null;
+      });
+
+      it('has _pie[1].model ', function(){
+        expect(el._pies['1'].model).to.eql({id: '1', value: 'model-result'});
+      });
+      
+      it('has _pie[1].session ', function(){
+        expect(el._pies['1'].session).to.eql({id: '1'});
+      });
+
       it('calls controller.model', function(){
-        sinon.assert.calledWith(mockController.model, ['1'], [{id: '1'}], {mode: 'gather'});
+        sinon.assert.calledWith(mockController.model, [{id: '1'}], {mode: 'gather'});
       });
     });
   </script>
 </body>
+
 </html>

--- a/test/index.test.html
+++ b/test/index.test.html
@@ -24,7 +24,7 @@
 
 <body>
   <pie-player>
-    <my-comp data-id="1"></my-comp>
+    <my-comp pie-id="1"></my-comp>
   </pie-player>
   <script>
 


### PR DESCRIPTION
fixes #2 

We were using `document.querySelectorAll('[data-id]')` to find pies within the `pie-player` instance, however this is prone to errors as non pie elements could have `data-id` set (ordering did). We could have looked at changing the attribute name to something a bit more unique, but I felt that it'd be worth using an event mechanism to handle the pie element initialisation. 

> This is a breaking change so existing pies will need to be updated.

A pie shall now dispatch an event `pie.register` in the `attachedCallback` handler. The event should bubble (`{bubble: true}`). The pie may include an `id` in the event detail (`{detail: {id: 'my-id'}}`), the player will try to use that and fall back to `[data-id]` if it's not present.

The player logic has been updated to handle the registration process.
